### PR TITLE
reverse_orientation se va,  areasine no caminaba

### DIFF
--- a/MENU.jl
+++ b/MENU.jl
@@ -8,8 +8,8 @@ using Profile
 @time R = read_region("./src/regions/mexico_water_bodies/Presa La Amistad.xyz")
 #R = EditBoundary.read_demo()
 # check polygon orientation
-@info "reverse_orientation"
-@time reverse_orientation!(R)
+# @info "reverse_orientation"
+# @time reverse_orientation!(R)
 # delete repeated points
 @info "del_repts"
 @time del_repts!(R)

--- a/src/geometry/AREA.jl
+++ b/src/geometry/AREA.jl
@@ -11,7 +11,7 @@
 
   Evaluation of the area functional at the triangle PQR.
   """
-  α(P::Vector{Float64}, Q::Vector{Float64}, R::Vector{Float64}) =
+  α(P::AbstractVector{T}, Q::AbstractVector{T}, R::AbstractVector{T}) where T =
   (Q[1]-P[1])*(R[2]-P[2]) + (Q[2]-P[2])*(P[1]-R[1])
 
   """

--- a/src/geometry/TRIANGLE_MEASURES.jl
+++ b/src/geometry/TRIANGLE_MEASURES.jl
@@ -4,9 +4,10 @@
 
 	Compute cos(Q) in the triangle PQR using the dot product
 	"""
-	function get_cos(P::Vector{Float64},
-					 Q::Vector{Float64},
-					 R::Vector{Float64})
+	function get_cos(P::AbstractVector{T},
+					 Q::AbstractVector{T},
+					 R::AbstractVector{T}
+					 ) where T
 
 		# vectors with starting point in Q
 	    v = P-Q
@@ -30,14 +31,14 @@
 
 	Area of triangle PQR
 	"""
-	areas(P::Vector{Float64}, Q::Vector{Float64}, R::Vector{Float64}) = 0.5abs(α(P,Q,R))
+	areas(P::AbstractVector{T}, Q::AbstractVector{T}, R::AbstractVector{T}) where T = 0.5abs(α(P,Q,R))
 
 	"""
 	    areasine(P,Q,R)
 
 	Area of triangle PQR weighted by the sine of the interior angle
 	"""
-	function areasine(P::Vector{Float64},Q::Vector{Float64},R::Vector{Float64})
+	function areasine(P::AbstractVector{T},Q::AbstractVector{T},R::AbstractVector{T}) where T
 	    # Compute cos(Q) using the dot product
 	    s  = get_cos(P,Q,R)
         # sin(Q) =√1-cos(Q)²


### PR DESCRIPTION
reverse_orientation  se puede eliminar

areasine no caminaba, 
cambio tipo de argumento en rutinas de AREA.jl y TRIANGLE_MEASURES.jl  para que corra